### PR TITLE
Enable Pages provisioning in deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -12,9 +12,18 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- grant the build job write permissions so the workflow can manage the Pages site
- enable GitHub Pages provisioning in the configure-pages step to initialize the site before deployment

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e002f7fa888326a383db8bb4020dff